### PR TITLE
Support `read(0)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,13 +12,13 @@ module.exports.open = function (p, options){
 
 var Reader = function (path, options){
   events.EventEmitter.call (this);
-  
+
   options = options || {};
   if (options.highWaterMark < 1){
     throw new Error ("Invalid highWaterMark");
   }
   this._highWaterMark = options.highWaterMark || 16384;
-  
+
   this._path = path;
   this._fd = null;
   this._p = 0;
@@ -32,9 +32,9 @@ var Reader = function (path, options){
   this._bufferMode = null;
   this._readFile = false;
   this._cancelled = false;
-  
+
   var me = this;
-  
+
   this._q = dq ().on ("error", function (error){
     if (!me._fd){
       me._q = null;
@@ -54,7 +54,7 @@ util.inherits (Reader, events.EventEmitter);
 
 Reader.prototype._open = function (cb){
   var me = this;
-  
+
   var open = function (){
     fs.open (me._path, "r", function (error, fd){
       if (error) return cb (error);
@@ -62,7 +62,7 @@ Reader.prototype._open = function (cb){
       cb ();
     });
   };
-  
+
   if (this._size === null){
     this._stats (function (error){
       if (error) return cb (error);
@@ -88,15 +88,15 @@ Reader.prototype._stats = function (cb){
 
 Reader.prototype.cancel = function (err){
   if (!this._q) throw new Error ("The reader is closed");
-  
+
   this._cancelled = true;
   this._q.pause ();
-  
+
   if (!this._fd){
     this._q = null;
     return err ? this.emit ("error", err) : this.emit ("close");
   }
-  
+
   var me = this;
   fs.close (this._fd, function (error){
     me._fd = null;
@@ -114,9 +114,9 @@ Reader.prototype.cancel = function (err){
 
 Reader.prototype.close = function (){
   if (!this._q) throw new Error ("The reader is closed");
-  
+
   var me = this;
-  
+
   this._q.push (function (done){
     if (!me._fd){
       me._q = null;
@@ -139,36 +139,36 @@ Reader.prototype.close = function (){
       me.emit ("close");
     }
   });
-  
+
   return this;
 };
 
 Reader.prototype.isEOF = function (){
   if (!this._q) throw new Error ("The reader is closed");
-  
+
   return this._size !== null && this._p >= this._size;
 };
 
 Reader.prototype._dump = function (target, offset, start, end, cb){
   var me = this;
-  
+
   var reads = Math.ceil ((end - start)/this._highWaterMark);
   var last = (end - start)%this._highWaterMark || this._highWaterMark;
-  
+
   (function read (reads){
     if (reads === 1){
       //Read to the buffer and copy to the target
       fs.read (me._fd, me._b, 0, me._highWaterMark, start,
           function (error, bytesRead){
         if (error) return cb (error);
-        
+
         //Update the buffer limits
         me._s = start;
         me._e = start + bytesRead;
-        
+
         //Fill the target buffer
         me._b.copy (target, offset, 0, last);
-        
+
         cb ();
       });
     }else{
@@ -176,10 +176,10 @@ Reader.prototype._dump = function (target, offset, start, end, cb){
       fs.read (me._fd, target, offset, me._highWaterMark, start,
           function (error, bytesRead){
         if (error) return cb (error);
-        
+
         offset += bytesRead;
         start += bytesRead;
-        
+
         read (reads - 1);
       });
     }
@@ -188,24 +188,24 @@ Reader.prototype._dump = function (target, offset, start, end, cb){
 
 Reader.prototype._read = function (bytes, cb){
   var me = this;
-  
+
   //Trim the number of bytes to read
   if (this._p + bytes >= this._size){
     bytes = this._size - this._p;
   }
-  
+
   var target = new Buffer (bytes);
-  
+
   if (!this._bufferMode){
     //File size <= buffer size
     if (!this._b) this._b = new Buffer (this._size);
-    
+
     var read = function (){
       me._b.copy (target, 0, me._p, me._p + bytes);
       me._p += bytes;
       cb (null, bytes, target);
     };
-    
+
     if (!this._readFile){
       //Read all the file
       fs.read (this._fd, this._b, 0, this._size, 0, function (error){
@@ -220,13 +220,13 @@ Reader.prototype._read = function (bytes, cb){
   }else{
     //File size > buffer size
     if (!this._b) this._b = new Buffer (this._highWaterMark);
-    
+
     var s = this._p;
     var e = this._p + bytes;
     //Check whether the limits are inside the buffer
     var is = s >= this._s && s < this._e;
     var ie = e > this._s && e <= this._e;
-    
+
     if (is && ie){
       //Case 1
       //The bytes to read are already in the buffer
@@ -235,7 +235,7 @@ Reader.prototype._read = function (bytes, cb){
       cb (null, bytes, target);
     }else if (!is && !ie){
       if (this._s >= s && this._s < e && this._e > s && this._e <= e){
-        
+
         //Case 5
         //The buffer is inside the requested bytes
         //Copy the bytes already in the buffer
@@ -287,10 +287,10 @@ Reader.prototype._read = function (bytes, cb){
 
 Reader.prototype.read = function (bytes, cb){
   if (!this._q) throw new Error ("The reader is closed");
-  if (~~bytes < 1) throw new Error ("Must read one or more bytes");
-  
+  if (~~bytes < 0) throw new Error ("Cannot read a negative number of bytes");
+
   var me = this;
-  
+
   this._q.push (function (done){
     //Fast case
     if (me.isEOF ()) return done (null, 0, new Buffer (0));
@@ -317,7 +317,7 @@ Reader.prototype.read = function (bytes, cb){
       }
     }
   });
-  
+
   return this;
 };
 
@@ -325,7 +325,7 @@ Reader.prototype._seek = function (offset, whence, cb){
   if (!whence){
     whence = { start: true };
   }
-  
+
   if (whence.start){
     this._p = offset;
   }else if (whence.current){
@@ -333,26 +333,26 @@ Reader.prototype._seek = function (offset, whence, cb){
   }else if (whence.end){
     this._p = this._size - 1 - offset;
   }
-  
+
   //An offset beyond the size - 1 limit will always return 0 bytes read, no need
   //to check and return an error
   if (this._p < 0){
     return cb (new Error ("The seek pointer must contain a positive value"));
   }
-  
+
   cb ();
 };
 
 Reader.prototype.seek = function (offset, whence, cb){
   if (!this._q) throw new Error ("The reader is closed");
-  
+
   var me = this;
-  
+
   if (arguments.length === 2 && typeof whence === "function"){
     cb = whence;
     whence = null;
   }
-  
+
   this._q.push (function (done){
     if (me._size === null){
       me._stats (function (error){
@@ -377,18 +377,18 @@ Reader.prototype.seek = function (offset, whence, cb){
       }
     }
   });
-  
+
   return this;
 };
 
 Reader.prototype.size = function (){
   if (!this._q) throw new Error ("The reader is closed");
-  
+
   return this._size;
 };
 
 Reader.prototype.tell = function (){
   if (!this._q) throw new Error ("The reader is closed");
-  
+
   return this._p;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,10 @@ var tests = {
           assert.strictEqual (bytesRead, 3);
           assert.deepEqual (buffer, new Buffer ([0, 1, 2]));
         })
+        .read (0, function (bytesRead, buffer){
+          assert.strictEqual (bytesRead, 0);
+          assert.deepEqual (buffer, new Buffer ([]));
+        })
         .close ();
   },
   "case 2": function (done){
@@ -243,7 +247,7 @@ var tests = {
     br.open (file)
         .on ("error", function (error){
           assert.ok (error);
-          
+
           br.open (file)
               .on ("error", function (error){
                 assert.ok (error);


### PR DESCRIPTION
Allowing `.read(0)` enables simpler code in cases like the following (which I just ran in to):

``` js
reader.read(0x2, function(byteCount, buffer) {
    // The next 2 bytes indicate the size of the string that follows.
    var descriptionLength = buffer.readUIntLE(0, byteCount);
    reader.read(descriptionLength, function(byteCount, buffer) {
        // Imagine lots of code here that reads the string.
        // The exact same code path must be taken if `descriptionLength == 0`,
        // but currently binary-reader doesn’t allow that and forces me to duplicate
        // code or to wrap everything in promises to avoid the sync/async difference.
        // This patch fixes all that by simply allowing `.read(0)`.
    });
```

Thanks for considering merging this. I really enjoy using this module in my hobby project!
